### PR TITLE
Proposal for image interface

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -1,0 +1,33 @@
+# Hacking Interconnect OpenShift image
+
+## Configure OpenShift
+Start local link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[OpenShift instance]
+```
+oc cluster up
+```
+```
+oc login -u system:admin
+USERNAME=dev
+NAMESPACE=interconnect
+oc policy add-role-to-user view $USERNAME -n default
+oc policy add-role-to-user system:image-pusher $USERNAME
+oc login -u $USERNAME -p " "
+oc new-project $NAMESPACE
+```
+
+## Build Image
+Install link:http://concreate.readthedocs.io/en/develop/installation.html[Concreate] container creation tool, then build image:
+```
+concreate build
+```
+
+## Deploy
+Load image into OpenShift registry and instantiate the template 
+```
+./load_registry.sh
+
+oc process -f templates/amq-interconnect-1-basic.yaml \
+ -p APPLICATION_NAMESPACE=$NAMESPACE  \
+ -p IMAGE_STREAM_NAMESPACE=$NAMESPACE \
+ | oc create -f -
+```

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 # Red Hat AMQ Interconnect OpenShift image
 
-NOTE: Extends link:https://access.redhat.com/containers/#/registry.access.redhat.com/rhel7[RHEL base image]
+NOTE: Extends link:https://github.com/jboss-container-images/jboss-base-image[JBoss base image]
 
 Provides AMQ Interconnect tools and OpenShift Integration
 
@@ -9,26 +9,8 @@ Provides AMQ Interconnect tools and OpenShift Integration
 . qdstat 
 
 
-## Run Interconnect in OpenShift
-
-Install link:http://concreate.readthedocs.io/en/develop/installation.html[Concreate] container creation tool, then build image:
-
-```
-concreate build
-```
-
-After logging into OpenShift instance ( oc login ), load the image into its registry
-```
-./load_registry
-```
-
-Then instantiate the template 
-```
-oc new-project myproject
-oc process -n myproject -f templates/amq-interconnect-1-basic.yaml -p APPLICATION_NAME=router-app | oc create -n myproject -f -
-```
+See HACKING.adoc for details on developing Interconnect Images
 
 # License
 
 See link:LICENSE[LICENSE] file.
-

--- a/image-streams.yaml
+++ b/image-streams.yaml
@@ -18,14 +18,14 @@ items:
     xpaas: 1.4.10
   spec:
     tags:
-    - name: '1.1'
+    - name: '1.0'
       annotations:
         description: Red Hat Interconnect 1.1 router image.
         iconClass: icon-amq
         tags: messaging,amq,jboss
         supports: interconnect:1.1,messaging
-        version: '1.1'
+        version: '1.0'
         openshift.io/display-name: Red Hat Interconnect 1.1
       from:
         kind: DockerImage
-        name: amq-interconnect-1/amq-interconnect-1-openshift:1.1
+        name: amq-interconnect-1/amq-interconnect-11-openshift:1.1

--- a/image.yaml
+++ b/image.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 
-name: "amq-interconnect-1/amq-interconnect-1-openshift"
+name: "amq-interconnect-1/amq-interconnect-11-openshift"
 description: "Red Hat AMQ Interconnect OpenShift container image"
 version: "1.1"
 from: "jboss/base-rhel7:latest"

--- a/image.yaml
+++ b/image.yaml
@@ -2,8 +2,8 @@ schema_version: 1
 
 name: "amq-interconnect-1/amq-interconnect-11-openshift"
 description: "Red Hat AMQ Interconnect OpenShift container image"
-version: "1.1"
-from: "jboss/base-rhel7:latest"
+version: "1.0"
+from: "jboss/base-rhel7:1.1"
 labels:    
     - name: "com.redhat.component"
       value: "amq-7-interconnect-11-openshift-container"
@@ -18,6 +18,7 @@ envs:
       value: "/opt/interconnect"
 ports:
     - value: 5672
+    - value: 55672
     - value: 8080
 modules:
       repositories:

--- a/load_registry.sh
+++ b/load_registry.sh
@@ -3,7 +3,7 @@ REGISTRY=$(oc get svc -n default | grep registry |  awk 'FNR == 1 {print $2}'):5
 docker login -p $(oc whoami -t) -u unused -e unused $REGISTRY
 
 BASE_NAME=amq-interconnect-1
-IMAGE_NAME=amq-interconnect-1-openshift
+IMAGE_NAME=amq-interconnect-11-openshift
 
 docker tag $BASE_NAME/$IMAGE_NAME:latest $REGISTRY/openshift/$IMAGE_NAME:latest
 docker push $REGISTRY/openshift/$IMAGE_NAME:latest 

--- a/load_registry.sh
+++ b/load_registry.sh
@@ -1,9 +1,36 @@
 #!/bin/sh
-REGISTRY=$(oc get svc -n default | grep registry |  awk 'FNR == 1 {print $2}'):5000
-docker login -p $(oc whoami -t) -u unused -e unused $REGISTRY
+# Loads router image into OpenShift registry
+OC_VERSION=$(oc version | grep openshift | grep -o "[0-9]\.[0-9]")
+NAMESPACE=$(oc project | cut -d '"' -f2 | cut -d '"' -f1)
 
 BASE_NAME=amq-interconnect-1
 IMAGE_NAME=amq-interconnect-11-openshift
 
-docker tag $BASE_NAME/$IMAGE_NAME:latest $REGISTRY/openshift/$IMAGE_NAME:latest
-docker push $REGISTRY/openshift/$IMAGE_NAME:latest 
+oc get svc -n default | grep registry 2>&1 > /dev/null
+ret=$?
+if [ $ret -eq 1 ]; then
+  # Cannot view registry in "default" namespace
+  echo "To add view permissions, as system:admin, run:"
+  echo ""
+  echo "oc policy add-role-to-user view $(oc whoami) -n default"
+  echo ""
+else
+  if [ $(echo "$OC_VERSION>=3.9" | bc -l) -eq 1 ]; then	
+    # If OpenShift version is >= 3.9
+    REGISTRY=$(oc get svc -n default | grep registry |  awk 'FNR == 1 {print $3}'):5000
+  else
+    REGISTRY=$(oc get svc -n default | grep registry |  awk 'FNR == 1 {print $2}'):5000
+  fi
+  
+  docker login -p $(oc whoami -t) -u unused $REGISTRY
+
+  docker tag $BASE_NAME/$IMAGE_NAME:latest $REGISTRY/$NAMESPACE/$IMAGE_NAME:latest
+  docker push $REGISTRY/$NAMESPACE/$IMAGE_NAME:latest
+  ret=$?
+  if [ $ret -eq 1 ]; then
+    echo "Give user permission to push to OpenShift registry, as system:admin, run:"
+    echo ""
+    echo "oc policy add-role-to-user system:image-pusher admin $(oc whoami)"
+    echo ""
+  fi
+fi

--- a/modules/interconnect-config/added/add_connectors.py
+++ b/modules/interconnect-config/added/add_connectors.py
@@ -1,0 +1,97 @@
+# FILE: add_connectors.py
+# DESC: Adds connectors to running router pods
+#################################################
+import time
+import json
+import httplib
+import ssl
+import os
+import sys
+
+TOKEN_FILE  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+CONFIG_FILE = sys.argv[1]
+
+IP=0 # Field to reference pod IP address
+TS=1 # Field to reference pod timestamp
+
+def retrieve_token():
+  with open(TOKEN_FILE, 'r') as f:
+    return f.read().replace('\n', '')
+
+def api_request(host, port, path, token):
+  ''' Makes REST request to API server and returns response'''
+  context = ssl._create_unverified_context()
+  conn = httplib.HTTPSConnection(host, port, timeout=5, context=context)
+  conn._context.check_hostname = False
+  conn._context.verify_mode = ssl.CERT_NONE
+  #conn.set_debuglevel(1)
+
+  headers = {}
+  headers['Authorization'] = "Bearer %s" % token
+
+  req = conn.request("GET", path , headers=headers)
+  res = conn.getresponse()
+
+  return res.read()
+
+def extract_ips(response, label):
+  ''' Given an API response, return list of pod ips ordered by pod start time'''
+  pod_list = []
+  js = json.loads(response)
+
+  for pod in js['items']:
+    # Filter non router pods
+    if('application' in pod['metadata']['labels'] and
+            pod['metadata']['labels']['application'] == label):
+      if('podIP' not in pod['status']):
+        print("Waiting for IP address...")
+        return None
+      ip = pod['status']['podIP']
+      st = pod['status']['startTime']
+
+      # Format timestamp so it can be sorted
+      timestamp = time.strptime(st, '%Y-%m-%dT%H:%M:%SZ')
+      pod_list.append([ip, timestamp])
+
+  # sort pods in ascending order by timestamp
+  pod_list.sort(key=lambda x: x[TS])
+
+  return [pod[IP] for pod in pod_list]
+
+def update_config(ip_list):
+  ''' Adds connectors to all running router pods '''
+  for ip in ip_list:
+    CONNECTOR = ("connector {\n"
+                 "  host: " + ip + "\n"
+                 "  port: 55672\n"
+                 "  role: inter-router\n"
+                 "  verifyHostName: no\n"
+                 "}\n\n"
+                )
+    with open(CONFIG_FILE, "a") as f:
+      f.write(CONNECTOR)
+
+host = os.environ['KUBERNETES_SERVICE_HOST']
+port = os.environ['KUBERNETES_PORT_443_TCP_PORT']
+ip   = os.environ['POD_IP']
+ns   = os.environ['POD_NAMESPACE']
+name = os.environ['APPLICATION_NAME']
+
+path = "/api/v1/namespaces/" + ns + "/pods"
+token = retrieve_token()
+ 
+while True:
+  # Send REST requests until other routers are ready
+  response = api_request(host, port, path, token)
+  ip_list  = extract_ips(response, name)
+  time.sleep(1)
+  if(ip_list is not None):
+      break
+
+# Get the ip addresses of the routers already running
+si = ip_list.index(ip)
+ip_list = ip_list[:si]
+
+print("Connecting to: ")
+print(ip_list)
+update_config(ip_list)

--- a/modules/interconnect-config/added/configure_interconnect.sh
+++ b/modules/interconnect-config/added/configure_interconnect.sh
@@ -2,7 +2,9 @@
 set -e
 
 INSTANCE_DIR=$1
-CONFIGMAP=${AMQ_HOME}/etc/configmap
+CONFIGBIN=${INSTANCE_DIR}/bin
+CONFIGDIR=${INSTANCE_DIR}/etc
+CONFIGMAP=${INSTANCE_DIR}/etc/configmap
 
 DISABLER_TAG="<!-- Remove this tag to enable custom configuration -->"
 
@@ -32,16 +34,20 @@ do
     
     if mount | grep $CONFIGMAP > /dev/null; then
       echo "ConfigMap volume mounted, copying over configuration files ..."
-      cp  $CONFIGMAP/$fname $INSTANCE_DIR/etc/$fname
+      cp  $CONFIGMAP/$fname $CONFIGDIR/$fname
     else
       echo "ConfigMap volume not mounted.."
       # Overwrite default configuration file
-      echo "$file_text" > $INSTANCE_DIR/etc/$fname
+      echo "$file_text" > $CONFIGDIR/$fname
     fi
  
   fi
 
   # Swap env vars into configuration file
-  swapVars $INSTANCE_DIR/etc/$fname
+  swapVars $CONFIGDIR/$fname
+
+  if [ "$fname" == "qdrouterd.conf" ]; then
+    python ${CONFIGBIN}/add_connectors.py $CONFIGDIR/$fname
+  fi
 
 done

--- a/modules/interconnect-launch/added/launch.sh
+++ b/modules/interconnect-launch/added/launch.sh
@@ -3,6 +3,10 @@
 
 CONFIG_FILE=${AMQ_HOME}/etc/qdrouterd.conf
 
-${AMQ_HOME}/bin/configure_interconnect.sh ${AMQ_HOME}
+${AMQ_HOME}/bin/configure_interconnect.sh ${AMQ_HOME} $CONFIG_FILE
 
-exec qdrouterd -c $CONFIG_FILE
+if [ -f $CONFIG_FILE ]; then
+    ARGS="-c $CONFIG_FILE"
+fi
+
+exec qdrouterd $ARGS

--- a/templates/amq-interconnect-1-alt.yaml
+++ b/templates/amq-interconnect-1-alt.yaml
@@ -1,0 +1,214 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: amq-interconnect-1-alt
+  annotations:
+    description: Template for Red Hat Interconnect Router using ConfigMap and StatefulSet.
+    iconClass: icon-amq
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: messaging,amq
+    version: 1.4.10
+    openshift.io/display-name: Red Hat Interconnect Router 1.x
+labels:
+  template: amq-interconnect-1-alt
+  xpaas: 1.4.10
+message: A new router service has been created in your project.
+parameters:
+- displayName: Application Name
+  description: The name for this deployment of the AMQ Interconnect Message Router.
+  name: APPLICATION_NAME
+  value: myrouter
+  required: true
+- displayName: ImageStream Namespace
+  description: Namespace in which the ImageStreams for Red Hat Middleware images are
+    installed. These ImageStreams are normally installed in the openshift namespace.
+    You should only need to modify this if you've installed the ImageStreams in a
+    different namespace/project.
+  name: IMAGE_STREAM_NAMESPACE
+  value: openshift
+- displayName: qdrouterd.conf
+  description: The initial router configuration file
+  name: QDROUTERD_CONF
+  value: |-
+    router {
+        mode: interior
+        id: ${HOSTNAME}
+    }
+
+    listener {
+        host: 0.0.0.0
+        port: amqp
+        authenticatePeer: no
+        saslMechanisms: ANONYMOUS
+    }
+
+    listener {
+        host: 0.0.0.0
+        port: amqps
+        authenticatePeer: no
+        saslMechanisms: ANONYMOUS
+        sslProfile: service_tls
+    }
+
+    listener {
+      host: 0.0.0.0
+      port: 55672
+      role: inter-router
+      authenticatePeer: no
+      saslMechanisms: ANONYMOUS
+      sslProfile: inter_router_tls
+    }
+
+    sslProfile {
+       name: service_tls
+       certFile: /etc/qpid-dispatch-certs/tls.crt
+       privateKeyFile: /etc/qpid-dispatch-certs/tls.key
+    }
+
+    sslProfile {
+       name: inter_router_tls
+       certFile: /etc/qpid-dispatch-certs/tls.crt
+       privateKeyFile: /etc/qpid-dispatch-certs/tls.key
+       caCertFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+    }
+
+    address {
+        prefix: closest
+        distribution: closest
+    }
+
+    address {
+        prefix: multicast
+        distribution: multicast
+    }
+
+    address {
+        prefix: unicast
+        distribution: closest
+    }
+
+    address {
+        prefix: exclusive
+        distribution: closest
+    }
+
+    address {
+        prefix: broadcast
+        distribution: multicast
+    }
+
+objects:
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}
+    labels:
+      application: ${APPLICATION_NAME}
+    annotations:
+      description: AMQ Interconnect Service.
+      service.alpha.openshift.io/serving-cert-secret-name: ${APPLICATION_NAME}-cert
+  spec:
+    ports:
+    - port: 5672
+      name: amqp
+      targetPort: 5672
+    - port: 5671
+      name: amqps
+      targetPort: 5671
+    - port: 55672
+      name: inter-router
+      targetPort: 55672
+    selector:
+      router-group: ${APPLICATION_NAME}
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}-headless
+    labels:
+      application: ${APPLICATION_NAME}
+    annotations:
+      description: Headless Service for StatefulSet.
+  spec:
+    ports:
+    - port: 55672
+      targetPort: 55672
+    selector:
+      router-group: ${APPLICATION_NAME}
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: ${APPLICATION_NAME}
+    labels:
+      application: ${APPLICATION_NAME}
+    annotations:
+      description: AMQ Interconnect Message Router.
+  spec:
+    serviceName: ${APPLICATION_NAME}-headless
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          application: ${APPLICATION_NAME}
+          router-group: ${APPLICATION_NAME}
+      spec:
+        containers:
+        - name: router
+          env:
+          - name: APPLICATION_NAME
+            value: "${APPLICATION_NAME}"
+          - name: QDROUTERD_CONF
+            value: "${QDROUTERD_CONF}"
+          - name: QDROUTERD_AUTO_MESH_DISCOVERY
+            value: "INFER"
+          image: amq-interconnect-11-openshift:latest
+          imagePullPolicy: Always
+          ports:
+          - name: amqp
+            containerPort: 5672
+            protocol: TCP
+          - name: amqps
+            containerPort: 5671
+            protocol: TCP
+          - name: inter-router
+            containerPort: 55672
+            protocol: TCP
+          volumeMounts:
+          - name: config
+            mountPath: /etc/qpid-dispatch
+          - name: certs
+            readOnly: true
+            mountPath: /etc/qpid-dispatch-certs/
+        volumes:
+        - name: config
+          configMap:
+            name: ${APPLICATION_NAME}
+        - name: certs
+          secret:
+            secretName: ${APPLICATION_NAME}-cert
+        serviceAccount: ${APPLICATION_NAME}
+        serviceAccountName: ${APPLICATION_NAME}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - router
+        from:
+          kind: ImageStreamTag
+          name: amq-interconnect-11-openshift:latest
+          namespace: ${IMAGE_STREAM_NAMESPACE}
+      type: ImageChange
+    - type: ConfigChange
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}
+    labels:
+      application: ${APPLICATION_NAME}
+  data:
+    qdrouterd.conf: ${QDROUTERD_CONF}
+- kind: ServiceAccount
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}
+    labels:
+      application: ${APPLICATION_NAME}

--- a/templates/amq-interconnect-1-basic.yaml
+++ b/templates/amq-interconnect-1-basic.yaml
@@ -6,7 +6,7 @@ metadata:
     description: Application template for Red Hat Interconnect Router.
     iconClass: icon-amq
     openshift.io/provider-display-name: Red Hat, Inc.
-    tags: messaging,amq,jboss,hidden
+    tags: messaging,amq
     version: 1.4.10
     openshift.io/display-name: Red Hat Interconnect Router 1.x
 labels:
@@ -17,6 +17,11 @@ parameters:
 - displayName: Application Name
   description: The name for the application.
   name: APPLICATION_NAME
+  value: router
+  required: true
+- displayName: Application Namespace
+  description: The namespace of the application.
+  name: APPLICATION_NAMESPACE
   value: router
   required: true
 - displayName: ImageStream Namespace
@@ -40,6 +45,14 @@ parameters:
         port: amqp
         authenticatePeer: no
         saslMechanisms: ANONYMOUS
+    }
+
+    listener {
+      host: 0.0.0.0
+      port: 55672
+      role: inter-router
+      authenticatePeer: no
+      saslMechanisms: ANONYMOUS
     }
 
     address {
@@ -66,6 +79,7 @@ parameters:
         prefix: broadcast
         distribution: multicast
     }
+
 objects:
 - kind: Service
   apiVersion: v1
@@ -79,6 +93,20 @@ objects:
     ports:
     - port: 5672
       targetPort: 5672
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}-inter
+    labels:
+      application: ${APPLICATION_NAME}
+    annotations:
+      description: The router's inter-router port.
+  spec:
+    ports:
+    - port: 55672
+      targetPort: 55672
     selector:
       deploymentConfig: ${APPLICATION_NAME}-amq
 - kind: Service
@@ -127,6 +155,7 @@ objects:
           deploymentConfig: "${APPLICATION_NAME}-amq"
           application: "${APPLICATION_NAME}"
       spec:
+        serviceAccountName: ${APPLICATION_NAME}
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-amq"
@@ -137,9 +166,22 @@ objects:
           - name: http
             containerPort: 8080
             protocol: TCP
+          - name: inter
+            containerPort: 55672
+            protocol: TCP
           env:
+          - name: APPLICATION_NAME
+            value: "${APPLICATION_NAME}"
           - name: QDROUTERD_CONF
             value: "${QDROUTERD_CONF}"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
             image: amq-interconnect-11-openshift:latest
           volumeMounts:
           - name: config-volume
@@ -156,3 +198,27 @@ objects:
     name: configmap
   data:
     qdrouterd.conf: ${QDROUTERD_CONF}
+- kind: ServiceAccount
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}
+- kind: Role
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}
+  rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+- kind: RoleBinding
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}
+  subjects:
+  - kind: ServiceAccount
+    name: ${APPLICATION_NAME}
+  roleRef:
+    kind: Role
+    name: ${APPLICATION_NAME}
+    namespace: ${APPLICATION_NAMESPACE}
+    apiGroup: rbac.authorization.k8s.io

--- a/templates/amq-interconnect-1-basic.yaml
+++ b/templates/amq-interconnect-1-basic.yaml
@@ -174,6 +174,8 @@ objects:
             value: "${APPLICATION_NAME}"
           - name: QDROUTERD_CONF
             value: "${QDROUTERD_CONF}"
+          - name: QDROUTERD_AUTO_MESH_DISCOVERY
+            value: "QUERY"
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/templates/amq-interconnect-1-basic.yaml
+++ b/templates/amq-interconnect-1-basic.yaml
@@ -115,7 +115,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: amq-interconnect-1-openshift:latest
+          name: amq-interconnect-11-openshift:latest
     - type: ConfigChange
     replicas: 1
     selector:
@@ -140,7 +140,7 @@ objects:
           env:
           - name: QDROUTERD_CONF
             value: "${QDROUTERD_CONF}"
-            image: amq-interconnect-1-openshift:latest
+            image: amq-interconnect-11-openshift:latest
           volumeMounts:
           - name: config-volume
             mountPath: /opt/interconnect/etc/configmap/

--- a/tests/features/interconnect.feature
+++ b/tests/features/interconnect.feature
@@ -1,15 +1,2 @@
 @amq-interconnect-1
 Feature: Configuration tests
-  Scenario: Check that Router config can be updated
-    When container is started with env
-       | variable     | value     |
-       | ROUTER_ID    | Router.B  |
-       | ROUTER_MODE  | interior  |
-    Then container log should contain Container Name: Router.B
-    And container log should contain Router started in Interior mode
-      
-  Scenario: Check that generic config can be updated
-    When container is started with env
-       | variable          | value     |
-       | LISTENER_HOST     | 0.1.0.0   |
-    Then container log should contain Listening on 0.1.0.0:amqp


### PR DESCRIPTION
Recognised environment variables:

QDROUTERD_CONF

This can contain either inline configuration, or a path that re used
to generate a config file which is used to start the router with. If
neither is supplied the default config file from the rpms will be
used.

If the variable contains what looks like inline configuration
(currently determined by the presence of curly braces), that
configuration is written to the generated config file.

Otherwise, if set, the variable is treated as a path. All files within
it are appended to the generated config file. For any directories in
the path, all the files ending in '.conf' within that directory are
appended to the generated config file.

Within the generated config file, some environment variable
substitution will be performed. At present the only variable that will
be substituted is $HOSTNAME. This allows for (but does not mandate)
router ids that are associated with the pod name for example.

QDROUTERD_AUTO_MESH_DISCOVERY

This determines whether any connectors are added to the generated
config file in order to establish a mesh as routers are scaled
up. This is only used if QDROUTERD_CONF is set.

There are two valid values at present:

1. QUERY

   This will query the kubernetes api server to determine which other
   pods it should connect to. It will connect to any pods (with label
   application set to the same value as the current pod) that started
   before it, based on the 'startTime' in the pod status. This can be
   used with any type of deployment. It may result in some number of
   stale connectors when router pods fail and are restarted, or if
   they are scaled up and down. These should not prevent normal
   functioning of the mesh. This mode requires that the service
   account the router is running under has view permission for pods.

2. INFER

   This mode of discovery can only be used with a StatefulSet. It
   infers the routers to connect to from its own hostname. (I.e. if it
   is myrouter-3, it will append connectors for myrouter-0 through
   myrouter-2).

If neither of these is specified, no connectors will be added to the
generated config file.

Also adds an alternate template for initial experimentation.