### PR TITLE
Some improvements to the basic template

### DIFF
--- a/templates/amq-interconnect-1-basic.yaml
+++ b/templates/amq-interconnect-1-basic.yaml
@@ -50,6 +50,29 @@ parameters:
       saslMechanisms: ANONYMOUS
     }
 
+    sslProfile {
+       name: service_tls
+       certFile: /etc/qpid-dispatch-certs/tls.crt
+       privateKeyFile: /etc/qpid-dispatch-certs/tls.key
+    }
+
+    listener {
+        host: 0.0.0.0
+        port: amqps
+        authenticatePeer: no
+        saslMechanisms: ANONYMOUS
+        sslProfile: service_tls
+    }
+
+    listener {
+        host: 0.0.0.0
+        port: 8080
+        authenticatePeer: no
+        saslMechanisms: ANONYMOUS
+        sslProfile: service_tls
+        http: true
+    }
+
     address {
         prefix: closest
         distribution: closest
@@ -79,43 +102,26 @@ objects:
 - kind: Service
   apiVersion: v1
   metadata:
-    name: ${APPLICATION_NAME}-amqp
+    name: ${APPLICATION_NAME}
     labels:
       application: ${APPLICATION_NAME}
     annotations:
       description: The router's AMQP port.
+      service.alpha.openshift.io/serving-cert-secret-name: ${APPLICATION_NAME}-cert
   spec:
     ports:
     - port: 5672
+      name: amqp
       targetPort: 5672
-    selector:
-      deploymentConfig: ${APPLICATION_NAME}-amq
-- kind: Service
-  apiVersion: v1
-  metadata:
-    name: ${APPLICATION_NAME}-inter
-    labels:
-      application: ${APPLICATION_NAME}
-    annotations:
-      description: The router's inter-router port.
-  spec:
-    ports:
-    - port: 55672
-      targetPort: 55672
-    selector:
-      deploymentConfig: ${APPLICATION_NAME}-amq
-- kind: Service
-  apiVersion: v1
-  metadata:
-    name: ${APPLICATION_NAME}-http
-    labels:
-      application: ${APPLICATION_NAME}
-    annotations:
-      description: The router's http port.
-  spec:
-    ports:
+    - port: 5671
+      name: amqps
+      targetPort: 5671
     - port: 8080
-      targetPort: 8080
+      name: http
+      targetPort: 5671
+    - port: 55672
+      name: inter-router
+      targetPort: 55672
     selector:
       deploymentConfig: ${APPLICATION_NAME}-amq
 - kind: DeploymentConfig
@@ -154,9 +160,12 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-amq"
-          ports: 
+          ports:
           - name: amqp
             containerPort: 5672
+            protocol: TCP
+          - name: amqps
+            containerPort: 5671
             protocol: TCP
           - name: http
             containerPort: 8080
@@ -180,7 +189,15 @@ objects:
               fieldRef:
                 fieldPath: status.podIP
             image: amq-interconnect-11-openshift:latest
+          volumeMounts:
+          - name: certs
+            readOnly: true
+            mountPath: /etc/qpid-dispatch-certs/
           terminationGracePeriodSeconds: 60
+        volumes:
+        - name: certs
+          secret:
+            secretName: ${APPLICATION_NAME}-cert
         imagePullPolicy: Always
 - kind: ServiceAccount
   apiVersion: v1

--- a/templates/amq-interconnect-1-basic.yaml
+++ b/templates/amq-interconnect-1-basic.yaml
@@ -17,7 +17,7 @@ parameters:
 - displayName: Application Name
   description: The name for the application.
   name: APPLICATION_NAME
-  value: router
+  value: amq-interconnect
   required: true
 - displayName: ImageStream Namespace
   description: Namespace in which the ImageStreams for Red Hat Middleware images are
@@ -123,11 +123,11 @@ objects:
       name: inter-router
       targetPort: 55672
     selector:
-      deploymentConfig: ${APPLICATION_NAME}-amq
+      deploymentConfig: ${APPLICATION_NAME}
 - kind: DeploymentConfig
   apiVersion: v1
   metadata:
-    name: "${APPLICATION_NAME}-amq"
+    name: "${APPLICATION_NAME}"
     labels:
       application: "${APPLICATION_NAME}"
   spec:
@@ -140,7 +140,7 @@ objects:
       imageChangeParams:
         automatic: true
         containerNames:
-        - "${APPLICATION_NAME}-amq"
+        - "${APPLICATION_NAME}"
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
@@ -148,18 +148,18 @@ objects:
     - type: ConfigChange
     replicas: 1
     selector:
-      deploymentConfig: "${APPLICATION_NAME}-amq"
+      deploymentConfig: "${APPLICATION_NAME}"
     template:
       metadata:
-        name: "${APPLICATION_NAME}-amq"
+        name: "${APPLICATION_NAME}"
         labels:
-          deploymentConfig: "${APPLICATION_NAME}-amq"
+          deploymentConfig: "${APPLICATION_NAME}"
           application: "${APPLICATION_NAME}"
       spec:
         serviceAccountName: ${APPLICATION_NAME}
         terminationGracePeriodSeconds: 60
         containers:
-        - name: "${APPLICATION_NAME}-amq"
+        - name: "${APPLICATION_NAME}"
           ports:
           - name: amqp
             containerPort: 5672

--- a/templates/amq-interconnect-1-basic.yaml
+++ b/templates/amq-interconnect-1-basic.yaml
@@ -19,11 +19,6 @@ parameters:
   name: APPLICATION_NAME
   value: router
   required: true
-- displayName: Application Namespace
-  description: The namespace of the application.
-  name: APPLICATION_NAMESPACE
-  value: router
-  required: true
 - displayName: ImageStream Namespace
   description: Namespace in which the ImageStreams for Red Hat Middleware images are
     installed. These ImageStreams are normally installed in the openshift namespace.
@@ -185,42 +180,18 @@ objects:
               fieldRef:
                 fieldPath: status.podIP
             image: amq-interconnect-11-openshift:latest
-          volumeMounts:
-          - name: config-volume
-            mountPath: /opt/interconnect/etc/configmap/
           terminationGracePeriodSeconds: 60
-        volumes:
-        - name: config-volume
-          configMap:
-            name: configmap
         imagePullPolicy: Always
-- kind: ConfigMap
-  apiVersion: v1
-  metadata:
-    name: configmap
-  data:
-    qdrouterd.conf: ${QDROUTERD_CONF}
 - kind: ServiceAccount
   apiVersion: v1
   metadata:
     name: ${APPLICATION_NAME}
-- kind: Role
-  apiVersion: v1
-  metadata:
-    name: ${APPLICATION_NAME}
-  rules:
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["list"]
 - kind: RoleBinding
   apiVersion: v1
   metadata:
-    name: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}-view
   subjects:
   - kind: ServiceAccount
     name: ${APPLICATION_NAME}
   roleRef:
-    kind: Role
-    name: ${APPLICATION_NAME}
-    namespace: ${APPLICATION_NAMESPACE}
-    apiGroup: rbac.authorization.k8s.io
+    name: "view"


### PR DESCRIPTION
* don't specify the configmap since we already have inline config (i.e. use one or the other not both)
* use the built-in 'view' permission to avoid needing to request namespace from user which is error prone