### PR TITLE
add support for generating sasldb on startup

### DIFF
--- a/load_registry.sh
+++ b/load_registry.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Loads router image into OpenShift registry
 OC_VERSION=$(oc version | grep openshift | grep -o "[0-9]\.[0-9]")
-NAMESPACE=$(oc project | cut -d '"' -f2 | cut -d '"' -f1)
+NAMESPACE=$(oc project -q)
 
 BASE_NAME=amq-interconnect
 IMAGE_NAME=amq-interconnect-1.2-openshift

--- a/modules/interconnect-config/added/configure_interconnect.sh
+++ b/modules/interconnect-config/added/configure_interconnect.sh
@@ -35,3 +35,7 @@ swapVars $OUTFILE
 if [ -n "$QDROUTERD_AUTO_MESH_DISCOVERY" ]; then
     python $HOME_DIR/bin/auto_mesh.py $OUTFILE
 fi
+
+if [ -n "$QDROUTERD_AUTO_CREATE_SASLDB_SOURCE" ]; then
+    $HOME_DIR/bin/create_sasldb.sh ${QDROUTERD_AUTO_CREATE_SASLDB_PATH:-$HOME_DIR/etc/qdrouterd.sasldb} $QDROUTERD_AUTO_CREATE_SASLDB_SOURCE "${APPLICATION_NAME:-amq-interconnect}"
+fi

--- a/modules/interconnect-config/added/create_sasldb.sh
+++ b/modules/interconnect-config/added/create_sasldb.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SASLDB=$1
+USER_DIR=$2
+DOMAIN=$3
+
+rm -rf $SASLDB
+for user in $USER_DIR/*; do
+    echo "cat $user | saslpasswd2 -c -p -u $DOMAIN $(basename $user) -f $SASLDB"
+    cat $user | saslpasswd2 -c -p -u $DOMAIN $(basename $user) -f $SASLDB
+done
+

--- a/templates/amq-interconnect-1-tls-auth.yaml
+++ b/templates/amq-interconnect-1-tls-auth.yaml
@@ -31,6 +31,13 @@ parameters:
   description: Name of secret containing CA certificate with which valid client certificates were signed.
   name: CLIENT_CA_SECRET
   value: client-ca
+- description: Username for access to console
+  name: USERNAME
+  value: admin
+- description: Password for access to console
+  from: '[A-Z0-9]{8}'
+  generate: expression
+  name: PASSWORD
 - displayName: ImageStream Namespace
   description: Namespace in which the ImageStreams for Red Hat Middleware images are
     installed. These ImageStreams are normally installed in the openshift namespace.
@@ -88,12 +95,18 @@ parameters:
         caCertFile: /etc/qpid-dispatch-certs/client-ca/ca.crt
     }
 
+    sslProfile {
+        name: console_tls
+        certFile: /etc/qpid-dispatch-certs/normal/tls.crt
+        keyFile: /etc/qpid-dispatch-certs/normal/tls.key
+    }
+
     listener {
         host: 0.0.0.0
         port: 8672
-        authenticatePeer: no
-        saslMechanisms: ANONYMOUS
-        sslProfile: service_tls
+        authenticatePeer: yes
+        saslMechanisms: PLAIN SCRAM-SHA-1
+        sslProfile: console_tls
         http: true
         httpRootDir: /usr/share/qpid-dispatch/console
     }
@@ -205,6 +218,10 @@ objects:
             value: "/etc/qpid-dispatch/qdrouterd.conf"
           - name: QDROUTERD_AUTO_MESH_DISCOVERY
             value: "QUERY"
+          - name: QDROUTERD_AUTO_CREATE_SASLDB_SOURCE
+            value: "/etc/qpid-dispatch-users"
+          - name: QDROUTERD_AUTO_CREATE_SASLDB_PATH
+            value: "/opt/interconnect/etc/qdrouterd.sasldb"
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
@@ -226,12 +243,18 @@ objects:
             mountPath: /etc/qpid-dispatch-certs/client-ca/
           - name: config-volume
             mountPath: /etc/qpid-dispatch/
+          - name: sasl-config
+            mountPath: /etc/sasl2/
+          - name: users
+            mountPath: /etc/qpid-dispatch-users
           terminationGracePeriodSeconds: 60
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /
               port: 8672
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /
               port: 8672
         volumes:
         - name: certs
@@ -243,6 +266,12 @@ objects:
         - name: client-ca
           secret:
             secretName: ${CLIENT_CA_SECRET}
+        - name: sasl-config
+          configMap:
+            name: ${APPLICATION_NAME}-sasl-config
+        - name: users
+          secret:
+            secretName: ${APPLICATION_NAME}-users
         - name: config-volume
           configMap:
             name: ${APPLICATION_NAME}
@@ -272,6 +301,14 @@ objects:
       application: ${APPLICATION_NAME}
   data:
     qdrouterd.conf: ${QDROUTERD_CONF}
+- kind: Secret
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}-users
+    labels:
+      application: ${APPLICATION_NAME}
+  stringData:
+    ${USERNAME}: ${PASSWORD}
 - kind: Route
   apiVersion: v1
   metadata:
@@ -285,4 +322,30 @@ objects:
       termination: passthrough
     to:
       kind: Service
-      name: amq-interconnect
+      name: ${APPLICATION_NAME}
+- kind: Route
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}-console
+    labels:
+      application: ${APPLICATION_NAME}
+  spec:
+    port:
+      targetPort: http
+    tls:
+      termination: passthrough
+    to:
+      kind: Service
+      name: ${APPLICATION_NAME}
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: ${APPLICATION_NAME}-sasl-config
+    labels:
+      application: ${APPLICATION_NAME}
+  data:
+    qdrouterd.conf: |-
+      pwcheck_method: auxprop
+      auxprop_plugin: sasldb
+      sasldb_path: /opt/interconnect/etc/qdrouterd.sasldb
+      mech_list: SCRAM-SHA-1 DIGEST-MD5 PLAIN EXTERNAL


### PR DESCRIPTION
 from secret mounted into the pod

Also update the tls_auth template to use this in order to secure the console automatically, with the user having the option of providing the username and password used if desired, or letting those be generated and then retreiving the info from the secret.